### PR TITLE
Fix regex escapes in entrypoint

### DIFF
--- a/sklearn2pmml/__init__.py
+++ b/sklearn2pmml/__init__.py
@@ -191,7 +191,7 @@ def _java_version(java_home = None):
 	return _parse_java_version(error)
 
 def _parse_java_version(java_version):
-	match = re.match("^(.*)\sversion\s\"(.*)\"(|\s.+)$", java_version, re.MULTILINE)
+	match = re.match(r"^(.*)\sversion\s\"(.*)\"(|\s.+)$", java_version, re.MULTILINE)
 	if match:
 		return (match.group(1), match.group(2))
 	else:
@@ -338,7 +338,7 @@ def sklearn2pmml(estimator, pmml_path, with_repr = False, java_home = None, java
 				os.remove(dump)
 
 def _parse_properties(lines):
-	splitter = re.compile("\s*=\s*")
+	splitter = re.compile(r"\s*=\s*")
 	properties = dict()
 	for line in lines:
 		line = line.decode("UTF-8").rstrip()


### PR DESCRIPTION
## Before this PR

We were encountering issue w/ invalid escape sequences (`\s`) when using this library to convert preprocessing components to PMML w/ Python 3.11

## After this PR
Fix regex escapes